### PR TITLE
Fix bad location for files when updating from 0.90

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -30,7 +30,8 @@ event_templates('nethserver-glpi-latest-update', qw(
 
 event_actions('nethserver-glpi-latest-update', qw(
   initialize-default-databases 00
-   nethserver-glpi-latest-conf 40
+  nethserver-glpi-latest-migrate-files-folder 10
+  nethserver-glpi-latest-conf 40
 ));
 
 event_services('nethserver-glpi-latest-update', qw(

--- a/root/etc/e-smith/events/actions/nethserver-glpi-latest-migrate-files-folder
+++ b/root/etc/e-smith/events/actions/nethserver-glpi-latest-migrate-files-folder
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Migrate the file folder for version 0.90 to the location used by 9.5.x 
+
+if [[ -d '/var/lib/glpi/files' ]]; then 
+
+    /usr/bin/cp -rf  /var/lib/glpi/files/* /var/lib/glpi/
+    /usr/bin/mv /var/lib/glpi/files /var/lib/glpi/files_migrated
+    /usr/bin/chown -R apache:apache /var/lib/glpi/
+else 
+    exit 0
+fi


### PR DESCRIPTION
0.90 stores files to /var/lib/glpi/files
9.5.x stores files to /var/lib/glpi